### PR TITLE
Fix for assignation client property and add describing the timeout of the request

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -57,6 +57,13 @@ class Client implements ClientInterface
     private $seconds = self::SECONDS;
 
     /**
+     * Timeout of every try
+     *
+     * @var float
+     */
+    private $maxRequestTimeout = self::MAX_REQUEST_TIMEOUT;
+
+    /**
      * Client constructor.
      *
      * @param Config $config User defined configuration
@@ -74,6 +81,11 @@ class Client implements ClientInterface
         // Waiting time
         if ($config->get('seconds') !== false) {
             $this->seconds = $config->get('seconds');
+        }
+
+        // Max request timeout per try
+        if ($config->get('maxRequestTimeout') !== false) {
+            $this->maxRequestTimeout = $config->get('maxRequestTimeout');
         }
 
         // Save config into local variable
@@ -98,7 +110,7 @@ class Client implements ClientInterface
 
             // Execute the request to server
             $result = \in_array($type, self::ALLOWED_METHODS, false)
-                ? $this->_client->request($type, $url, ['form_params' => $params])
+                ? $this->_client->request($type, $url, ['timeout' => $this->maxRequestTimeout, 'form_params' => $params])
                 : null;
 
             // Check the code status

--- a/src/Client.php
+++ b/src/Client.php
@@ -73,7 +73,7 @@ class Client implements ClientInterface
 
         // Waiting time
         if ($config->get('seconds') !== false) {
-            $this->tries = $config->get('seconds');
+            $this->seconds = $config->get('seconds');
         }
 
         // Save config into local variable

--- a/src/Config.php
+++ b/src/Config.php
@@ -81,7 +81,7 @@ class Config implements ConfigInterface
      * @param   array $ignore_items Which items should be excluded from array
      * @return  array
      */
-    public function getParameters($ignore = false, array $ignore_items = ['token', 'tries', 'seconds'])
+    public function getParameters($ignore = false, array $ignore_items = ['token', 'tries', 'seconds', 'maxRequestTimeout'])
     {
         $parameters = $this->_parameters;
         // Remove ignored items from array

--- a/src/Interfaces/ClientInterface.php
+++ b/src/Interfaces/ClientInterface.php
@@ -24,4 +24,9 @@ interface ClientInterface
      * Waiting time
      */
     const SECONDS = 1;
+
+    /**
+     * Max request timeout per try
+     */
+    const MAX_REQUEST_TIMEOUT = 10.0;
 }


### PR DESCRIPTION
Исправлено назначение свойства при создании экземпляра класса `UON\Client`.

Добавлено ограничение на выполнение запроса. Со слов технической поддержки, запрос не должен выполняться дольше 5-10 секунд, однако бывают случаи, когда запросы выполняются дольше минуты.