### PR TITLE
solution of the 'tries' parameter incorrectness

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -106,7 +106,7 @@ class Client implements ClientInterface
      */
     public function repeatRequest($type, $url, $params)
     {
-        for ($i = 1; $i < $this->tries; $i++) {
+        for ($i = 0; $i < $this->tries; $i++) {
 
             // Execute the request to server
             $result = \in_array($type, self::ALLOWED_METHODS, false)


### PR DESCRIPTION
Исправление поведения цикла.
Данный цикл выполнял `$this->tries - 1` попыток запросов, что, при установке параметра `tries` равным `1`, приводило к ошибкам в работе (запросы не выполнялись вообще).